### PR TITLE
merge some methodes from celements-core to celements-photo

### DIFF
--- a/component/src/main/java/com/celements/photo/service/ImageScriptService.java
+++ b/component/src/main/java/com/celements/photo/service/ImageScriptService.java
@@ -43,6 +43,7 @@ import com.celements.photo.utilities.ImportFileObject;
 import com.celements.sajson.Builder;
 import com.celements.web.service.CelementsWebScriptService;
 import com.celements.web.service.IWebUtilsService;
+import com.celements.web.utils.WebUtils;
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.api.Attachment;
@@ -300,6 +301,16 @@ public class ImageScriptService implements ScriptService {
 
   public String fixMaxImageSizes(String pageContent, int maxWidth, int maxHeight) {
     return maxImageSizeService.fixMaxImageSizes(pageContent, maxWidth, maxHeight);
+  }
+  
+  public List<Attachment> getRandomImages(String fullName,
+      int num) throws ClassNotFoundException{
+    return WebUtils.getInstance().getRandomImages(fullName, num, getContext());
+  }
+  
+  public boolean useImageAnimations() {
+    return "1".equals(getContext().getWiki().getSpacePreference("celImageAnimation",
+        "celements.celImageAnimation", "0", getContext()));
   }
 
 }

--- a/component/src/main/java/com/celements/photo/service/ImageScriptService.java
+++ b/component/src/main/java/com/celements/photo/service/ImageScriptService.java
@@ -304,7 +304,7 @@ public class ImageScriptService implements ScriptService {
   }
   
   public List<Attachment> getRandomImages(String fullName,
-      int num) throws ClassNotFoundException{
+      int num) {
     return WebUtils.getInstance().getRandomImages(fullName, num, getContext());
   }
   


### PR DESCRIPTION
merge all methods into celements-photo-component com.celements.photo.service.ImageScriptService from ImageScriptService.java in the celements-core. Keep their original implementation in the CelementsWebApi and just mark them deprecated (to prevent cyclic dependency)
