### PR TITLE
Move XML templates and context menus to correct web-module subprojects

### DIFF
--- a/web-module/src/main/webapp/docs/celements2web/CelementsContextMenu/cel_cm_celimage_slideshow.xml
+++ b/web-module/src/main/webapp/docs/celements2web/CelementsContextMenu/cel_cm_celimage_slideshow.xml
@@ -3,7 +3,7 @@
 <web>CelementsContextMenu</web>
 <name>cel_cm_celimage_slideshow</name>
 <language></language>
-<defaultLanguage>en</defaultLanguage>
+<defaultLanguage></defaultLanguage>
 <translation>0</translation>
 <parent></parent>
 <creator>xwiki:XWiki.fpichler</creator>

--- a/web-module/src/main/webapp/docs/celements2web/CelementsContextMenu/cel_cm_gallery.xml
+++ b/web-module/src/main/webapp/docs/celements2web/CelementsContextMenu/cel_cm_gallery.xml
@@ -3,7 +3,7 @@
 <web>CelementsContextMenu</web>
 <name>cel_cm_gallery</name>
 <language></language>
-<defaultLanguage>en</defaultLanguage>
+<defaultLanguage></defaultLanguage>
 <translation>0</translation>
 <parent></parent>
 <creator>xwiki:XWiki.raphael</creator>

--- a/web-module/src/main/webapp/docs/celements2web/CelementsContextMenu/cel_cm_gallery_list.xml
+++ b/web-module/src/main/webapp/docs/celements2web/CelementsContextMenu/cel_cm_gallery_list.xml
@@ -3,7 +3,7 @@
 <web>CelementsContextMenu</web>
 <name>cel_cm_gallery_list</name>
 <language></language>
-<defaultLanguage>en</defaultLanguage>
+<defaultLanguage></defaultLanguage>
 <translation>0</translation>
 <parent></parent>
 <creator>xwiki:XWiki.raphael</creator>

--- a/web-module/src/main/webapp/docs/celements2web/CelementsContextMenu/cel_cm_gallery_view.xml
+++ b/web-module/src/main/webapp/docs/celements2web/CelementsContextMenu/cel_cm_gallery_view.xml
@@ -3,7 +3,7 @@
 <web>CelementsContextMenu</web>
 <name>cel_cm_gallery_view</name>
 <language></language>
-<defaultLanguage>en</defaultLanguage>
+<defaultLanguage></defaultLanguage>
 <translation>0</translation>
 <parent></parent>
 <creator>xwiki:XWiki.raphael</creator>

--- a/web-module/src/main/webapp/docs/celements2web/PageTypes/Gallery.xml
+++ b/web-module/src/main/webapp/docs/celements2web/PageTypes/Gallery.xml
@@ -3,7 +3,7 @@
 <web>PageTypes</web>
 <name>Gallery</name>
 <language></language>
-<defaultLanguage>en</defaultLanguage>
+<defaultLanguage></defaultLanguage>
 <translation>0</translation>
 <parent></parent>
 <creator>xwiki:XWiki.fpichler</creator>
@@ -292,6 +292,22 @@
 <unmodifiable>0</unmodifiable>
 <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
 </filepath>
+<isRteContent>
+<cache>0</cache>
+<disabled>0</disabled>
+<displayType>select</displayType>
+<multiSelect>0</multiSelect>
+<name>isRteContent</name>
+<number>3</number>
+<prettyName>Is Rte Content</prettyName>
+<relationalStorage>0</relationalStorage>
+<separator> </separator>
+<separators>|</separators>
+<size>1</size>
+<unmodifiable>0</unmodifiable>
+<values>NO|BOTH|ONLY</values>
+<classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+</isRteContent>
 <loadMode>
 <cache>0</cache>
 <disabled>0</disabled>

--- a/web-module/src/main/webapp/docs/celements2web/PageTypes/GalleryList.xml
+++ b/web-module/src/main/webapp/docs/celements2web/PageTypes/GalleryList.xml
@@ -3,7 +3,7 @@
 <web>PageTypes</web>
 <name>GalleryList</name>
 <language></language>
-<defaultLanguage>de</defaultLanguage>
+<defaultLanguage></defaultLanguage>
 <translation>0</translation>
 <parent></parent>
 <creator>xwiki:XWiki.fpichler</creator>

--- a/web-module/src/main/webapp/docs/celements2web/PageTypes/GalleryList.xml
+++ b/web-module/src/main/webapp/docs/celements2web/PageTypes/GalleryList.xml
@@ -3,7 +3,7 @@
 <web>PageTypes</web>
 <name>GalleryList</name>
 <language></language>
-<defaultLanguage>en</defaultLanguage>
+<defaultLanguage>de</defaultLanguage>
 <translation>0</translation>
 <parent></parent>
 <creator>xwiki:XWiki.fpichler</creator>

--- a/web-module/src/main/webapp/docs/celements2web/PageTypes/ImageSlide.xml
+++ b/web-module/src/main/webapp/docs/celements2web/PageTypes/ImageSlide.xml
@@ -3,7 +3,7 @@
 <web>PageTypes</web>
 <name>ImageSlide</name>
 <language></language>
-<defaultLanguage>en</defaultLanguage>
+<defaultLanguage></defaultLanguage>
 <translation>0</translation>
 <parent></parent>
 <creator>xwiki:XWiki.fpichler</creator>


### PR DESCRIPTION
This change refactors the location of various XML templates, page types, and context menus. Files that were previously added or modified in the main `celements-web` repository but logically belong to other component repositories have been relocated to their correct web-module subprojects. 

Across all touched repositories, these changes have been committed and pushed under the branch:
`update-celements2web-7x-onDisk`
